### PR TITLE
Write converter for Unix to Windows paths

### DIFF
--- a/recs/cfg/path_pattern.py
+++ b/recs/cfg/path_pattern.py
@@ -92,6 +92,10 @@ class PathPattern:
         )
         return Path(p)
 
+    def unix_to_windows_path(self, unix_path: str) -> str:
+        """Converts a Unix-style file path to a Windows-style path"""
+        return unix_path.replace('/', '\\')
+
 
 DATE = {Req.year, Req.month, Req.day}
 TIME = {Req.hour, Req.minute, Req.second}

--- a/recs/cfg/path_pattern.py
+++ b/recs/cfg/path_pattern.py
@@ -92,10 +92,6 @@ class PathPattern:
         )
         return Path(p)
 
-    def unix_to_windows_path(self, unix_path: str) -> str:
-        """Converts a Unix-style file path to a Windows-style path"""
-        return unix_path.replace('/', '\\')
-
 
 DATE = {Req.year, Req.month, Req.day}
 TIME = {Req.hour, Req.minute, Req.second}

--- a/test/cfg/test_cli.py
+++ b/test/cfg/test_cli.py
@@ -4,5 +4,16 @@ import subprocess as sp
 
 def test_info():
     cmd = 'python -m recs --info'.split()
-    r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE).stdout
-    json.loads(r)
+    try:
+        r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE).stdout
+    except sp.CalledProcessError:
+        # On Windows, Python installation can also be via the Windows store
+        # When installed in this way, the python.exe acts as a "launcher" for the Python interpreter
+        # It may not behave like a standalone executable, which can lead to issues
+        # Especially when invoking subprocess commands.
+        # A safety check is to ask the subprocess to run in a shell
+        # This is an "except" case because not all Python installations are via Windows store
+        # And it'll be more overhead unless absolutely necessary
+        r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE, shell=True).stdout
+    finally:
+        json.loads(r)

--- a/test/cfg/test_cli.py
+++ b/test/cfg/test_cli.py
@@ -4,16 +4,5 @@ import subprocess as sp
 
 def test_info():
     cmd = 'python -m recs --info'.split()
-    try:
-        r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE).stdout
-    except sp.CalledProcessError:
-        # On Windows, Python installation can also be via the Windows store
-        # When installed in this way, the python.exe acts as a "launcher" for the Python interpreter
-        # It may not behave like a standalone executable, which can lead to issues
-        # Especially when invoking subprocess commands.
-        # A safety check is to ask the subprocess to run in a shell
-        # This is an "except" case because not all Python installations are via Windows store
-        # And it'll be more overhead unless absolutely necessary
-        r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE, shell=True).stdout
-    finally:
-        json.loads(r)
+    r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE, shell=True).stdout
+    json.loads(r)

--- a/test/cfg/test_cli.py
+++ b/test/cfg/test_cli.py
@@ -3,6 +3,6 @@ import subprocess as sp
 
 
 def test_info():
-    cmd = 'python -m recs --info'.split()
+    cmd = 'python -m recs --info'
     r = sp.run(cmd, text=True, check=True, stdout=sp.PIPE, shell=True).stdout
     json.loads(r)

--- a/test/cfg/test_path_pattern.py
+++ b/test/cfg/test_path_pattern.py
@@ -1,5 +1,6 @@
 from test.conftest import TIME, TIMESTAMP
 
+import os
 import pytest
 
 from recs.base import RecsError
@@ -46,7 +47,7 @@ def test_simple(mock_devices):
         index=1,
     )
     expected = '164921/20231015/Ext + 1'
-    assert str(actual) == pp.unix_to_windows_path(expected)
+    assert str(actual) == os.path.normpath(expected)
 
 
 def test_mix(mock_devices):
@@ -64,7 +65,8 @@ def test_mix(mock_devices):
         index=1,
     )
     expected = 'Ext/2023/10/1 + 15-164921'
-    assert str(actual) == pp.unix_to_windows_path(expected)
+
+    assert str(actual) == os.path.normpath(expected)
 
 
 def test_index(mock_devices):
@@ -77,7 +79,7 @@ def test_index(mock_devices):
         index=1,
     )
     expected = 'recording/Ext + 1/1'
-    assert str(actual) == pp.unix_to_windows_path(expected)
+    assert str(actual) == os.path.normpath(expected)
 
 
 def test_bad_field(mock_devices):

--- a/test/cfg/test_path_pattern.py
+++ b/test/cfg/test_path_pattern.py
@@ -1,6 +1,5 @@
 from test.conftest import TIME, TIMESTAMP
 
-import os
 import pytest
 
 from recs.base import RecsError
@@ -29,7 +28,7 @@ def test_empty(mock_devices):
         index=1,
     )
     expected = 'Ext + 1 + 20231015-164921'
-    assert str(actual) == expected
+    assert actual.match(expected)
 
 
 def test_simple(mock_devices):
@@ -47,7 +46,7 @@ def test_simple(mock_devices):
         index=1,
     )
     expected = '164921/20231015/Ext + 1'
-    assert str(actual) == os.path.normpath(expected)
+    assert actual.match(expected)
 
 
 def test_mix(mock_devices):
@@ -66,7 +65,7 @@ def test_mix(mock_devices):
     )
     expected = 'Ext/2023/10/1 + 15-164921'
 
-    assert str(actual) == os.path.normpath(expected)
+    assert actual.match(expected)
 
 
 def test_index(mock_devices):
@@ -79,7 +78,7 @@ def test_index(mock_devices):
         index=1,
     )
     expected = 'recording/Ext + 1/1'
-    assert str(actual) == os.path.normpath(expected)
+    assert actual.match(expected)
 
 
 def test_bad_field(mock_devices):

--- a/test/cfg/test_path_pattern.py
+++ b/test/cfg/test_path_pattern.py
@@ -46,7 +46,7 @@ def test_simple(mock_devices):
         index=1,
     )
     expected = '164921/20231015/Ext + 1'
-    assert str(actual) == expected
+    assert str(actual) == pp.unix_to_windows_path(expected)
 
 
 def test_mix(mock_devices):
@@ -64,7 +64,7 @@ def test_mix(mock_devices):
         index=1,
     )
     expected = 'Ext/2023/10/1 + 15-164921'
-    assert str(actual) == expected
+    assert str(actual) == pp.unix_to_windows_path(expected)
 
 
 def test_index(mock_devices):
@@ -77,7 +77,7 @@ def test_index(mock_devices):
         index=1,
     )
     expected = 'recording/Ext + 1/1'
-    assert str(actual) == expected
+    assert str(actual) == pp.unix_to_windows_path(expected)
 
 
 def test_bad_field(mock_devices):


### PR DESCRIPTION
My attempt at fixing the 4 failing tests on Windows.

```bash
=================================================== short test summary info =================================================== 
FAILED test/cfg/test_cli.py::test_info - subprocess.CalledProcessError: Command '['python', '-m', 'recs', '--info']' returned non-zero exit status 1.
FAILED test/cfg/test_path_pattern.py::test_simple - AssertionError: assert '164921\\20231015\\Ext + 1' == '164921/20231015/Ext + 1'
FAILED test/cfg/test_path_pattern.py::test_mix - AssertionError: assert 'Ext\\2023\\10\\1 + 15-164921' == 'Ext/2023/10/1 + 15-164921'
FAILED test/cfg/test_path_pattern.py::test_index - AssertionError: assert 'recording\\Ext + 1\\1' == 'recording/Ext + 1/1'
```

## Fixed so far
- [x] `test_path_pattern.py::test_index`
- [x] `test_path_pattern.py::test_index`
- [x] `test_path_pattern.py::test_index`
- [x] `test_cli.py::test_info`